### PR TITLE
Fix #644: Use `Buffer.t` instead of `Bi_outbuf.t`

### DIFF
--- a/core/KaSa_rep/frontend/ckappa_sig.ml
+++ b/core/KaSa_rep/frontend/ckappa_sig.ml
@@ -146,12 +146,12 @@ let rule_id_of_json json =
     raise (Yojson.Basic.Util.Type_error (JsonUtil.build_msg "rule id",json))
 
 let write_c_rule_id ob f =
-  Yojson.Basic.to_outbuf ob (rule_id_to_json f)
+  Yojson.Basic.to_buffer ob (rule_id_to_json f)
 
 let string_of_c_rule_id ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
+  let ob = Buffer.create len in
   write_c_rule_id ob x;
-  Bi_outbuf.contents ob
+  Buffer.contents ob
 
 let read_c_rule_id p lb =
   rule_id_of_json (Yojson.Basic.from_lexbuf ~stream:true p lb)

--- a/core/KaSa_rep/frontend/ckappa_sig.mli
+++ b/core/KaSa_rep/frontend/ckappa_sig.mli
@@ -37,7 +37,7 @@ type c_counter_name
 
 val rule_id_to_json : c_rule_id -> Yojson.Basic.t
 val rule_id_of_json : Yojson.Basic.t -> c_rule_id
-val write_c_rule_id : Bi_outbuf.t -> c_rule_id -> unit
+val write_c_rule_id : Buffer.t -> c_rule_id -> unit
 val string_of_c_rule_id : ?len:int -> c_rule_id -> string
 val read_c_rule_id : Yojson.Safe.lexer_state -> Lexing.lexbuf -> c_rule_id
 val c_rule_id_of_string : string -> c_rule_id

--- a/core/api/kamoha_client.ml
+++ b/core/api/kamoha_client.ml
@@ -56,7 +56,7 @@ class virtual new_client ~post mailbox :
   method virtual is_running : bool
 
   method private message :
-    type a. a handle -> (Bi_outbuf.t -> unit) ->
+    type a. a handle -> (Buffer.t -> unit) ->
     (a, Result_util.message list) Result_util.t Lwt.t =
     fun handle request ->
     if self#is_running then

--- a/core/api/kasa_client.ml
+++ b/core/api/kasa_client.ml
@@ -49,13 +49,13 @@ class new_client ~is_running ~post (mailbox : mailbox) :
     method private raw_message post request =
       if is_running () then
         let result,feeder = Lwt.task () in
-        let outbuf = Bi_outbuf.create 1024 in
-        let () = Bi_outbuf.add_string outbuf "{id:" in
-        let () = Bi_outbuf.add_string outbuf (string_of_int id) in
-        let () = Bi_outbuf.add_string outbuf ",data:" in
+        let outbuf = Buffer.create 1024 in
+        let () = Buffer.add_string outbuf "{id:" in
+        let () = Buffer.add_string outbuf (string_of_int id) in
+        let () = Buffer.add_string outbuf ",data:" in
         let () = request outbuf in
-        let () = Bi_outbuf.add_string outbuf "}" in
-        let () = post (Bi_outbuf.contents outbuf) in
+        let () = Buffer.add_string outbuf "}" in
+        let () = post (Buffer.contents outbuf) in
         let () = Hashtbl.replace mailbox id feeder in
         let () = id <- id+1 in
         result
@@ -68,13 +68,13 @@ class new_client ~is_running ~post (mailbox : mailbox) :
                 Exit)
              Exception_without_parameter.empty_error_handler)
     method private message request =
-      self#raw_message post (fun outb -> Yojson.Basic.to_outbuf outb request)
+      self#raw_message post (fun outb -> Yojson.Basic.to_buffer outb request)
 
     method init_static_analyser_raw compil =
       let request outbuf =
-        let () = Bi_outbuf.add_string outbuf "[ \"INIT\", " in
-        let () = Bi_outbuf.add_string outbuf compil in
-        Bi_outbuf.add_string outbuf "]" in
+        let () = Buffer.add_string outbuf "[ \"INIT\", " in
+        let () = Buffer.add_string outbuf compil in
+        Buffer.add_string outbuf "]" in
       Lwt_result.bind_result
         (self#raw_message post request)
         (function

--- a/core/api/switchman_client.ml
+++ b/core/api/switchman_client.ml
@@ -152,7 +152,7 @@ class virtual new_client ~is_running ~post mailbox = object(self)
   val mutable id = 0
 
   method private message :
-    type a. a handle -> (Bi_outbuf.t -> unit) ->
+    type a. a handle -> (Buffer.t -> unit) ->
     (a, Result_util.message list) Result_util.t Lwt.t =
     fun handle request ->
     if is_running () then

--- a/core/api/switchman_client.mli
+++ b/core/api/switchman_client.mli
@@ -127,7 +127,7 @@ class virtual new_client :
     method private message :
       'a.
         'a handle ->
-        (Bi_outbuf.t -> unit) ->
+        (Buffer.t -> unit) ->
         ('a, Kappa_generic_toolset.Result_util.message list)
         Kappa_generic_toolset.Result_util.t Lwt.t
     method project_overwrite :

--- a/core/dataStructures/jsonUtil.ml
+++ b/core/dataStructures/jsonUtil.ml
@@ -6,15 +6,17 @@
 (* |_|\_\ * GNU Lesser General Public License Version 3                       *)
 (******************************************************************************)
 
+let initial_buffer_size = 0x1000
+
 let write_to_channel f d x =
-  let b = Bi_outbuf.create_channel_writer d in
+  let b = Buffer.create initial_buffer_size in
   let () = f b x in
-  Bi_outbuf.flush_channel_writer b
+  Buffer.output_buffer d b
 
 let string_of_write f ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
+  let ob = Buffer.create len in
   let () = f ob x in
-  Bi_outbuf.contents ob
+  Buffer.contents ob
 
 let read_of_string f x =
   let lex_st = Yojson.Basic.init_lexer () in
@@ -89,18 +91,18 @@ let to_list ?error_msg:(error_msg=build_msg "list") of_json = function
   | `Null -> []
   | x -> raise (Yojson.Basic.Util.Type_error (error_msg,x))
 
-let write_comma ob = Bi_outbuf.add_char ob ','
+let write_comma ob = Buffer.add_char ob ','
 
 let rec iter2 f_elt x = function
   | [] -> ()
   | y :: l -> write_comma x; f_elt x y; iter2 f_elt x l
 
 let write_list f ob l =
-  let () = Bi_outbuf.add_char ob '[' in
+  let () = Buffer.add_char ob '[' in
   let () = match l with
     | [] -> ()
     | y :: l -> f ob y; iter2 f ob l in
-  Bi_outbuf.add_char ob ']'
+  Buffer.add_char ob ']'
 
 let of_array to_json a =
   `List (Array.fold_right (fun x acc -> to_json x::acc) a [])
@@ -111,12 +113,12 @@ let to_array ?error_msg:(error_msg=build_msg "array") of_json = function
   | x -> raise (Yojson.Basic.Util.Type_error (error_msg,x))
 
 let write_array f ob l =
-  let () = Bi_outbuf.add_char ob '[' in
+  let () = Buffer.add_char ob '[' in
   let () = if Array.length l > 0 then f ob l.(0) in
   let () = Tools.iteri
       (fun i -> let () = write_comma ob in f ob l.(succ i))
       (pred (Array.length l)) in
-  Bi_outbuf.add_char ob ']'
+  Buffer.add_char ob ']'
 
 let rec iter_seq ob = function
   | [] -> ()
@@ -126,11 +128,11 @@ let rec iter_seq ob = function
     iter_seq ob q
 
 let write_sequence ob l =
-  let () = Bi_outbuf.add_char ob '[' in
+  let () = Buffer.add_char ob '[' in
   let () = match l with
     | [] -> ()
     | f::q -> let () = f ob in iter_seq ob q in
-  Bi_outbuf.add_char ob ']'
+  Buffer.add_char ob ']'
 
 let read_variant read_id read st b =
   let () = Yojson.Basic.read_lbr st b in
@@ -164,7 +166,7 @@ let to_assoc
 
 let write_field na f ob x =
   let () = Yojson.Basic.write_string ob na in
-  let () = Bi_outbuf.add_char ob ':' in
+  let () = Buffer.add_char ob ':' in
   f ob x
 
 let of_pair ?(lab1="first") ?(lab2="second") to_json1 to_json2 (a,b) =
@@ -206,11 +208,11 @@ let to_pair ?lab1:(lab1="first") ?lab2:(lab2="second")
     raise (Yojson.Basic.Util.Type_error (error_msg,x))
 
 let write_compact_pair f g ob (x,y) =
-  let () = Bi_outbuf.add_char ob '[' in
+  let () = Buffer.add_char ob '[' in
   let () = f ob x in
   let () = write_comma ob in
   let () = g ob y in
-  Bi_outbuf.add_char ob ']'
+  Buffer.add_char ob ']'
 
 let read_compact_pair f g st b =
   let () = Yojson.Basic.read_lbr st b in

--- a/core/dataStructures/jsonUtil.mli
+++ b/core/dataStructures/jsonUtil.mli
@@ -8,8 +8,8 @@
 
 (** Parsing utils *)
 
-val write_to_channel: (Bi_outbuf.t -> 'a -> unit) -> out_channel -> 'a -> unit
-val string_of_write: (Bi_outbuf.t -> 'a -> unit) -> ?len:int -> 'a -> string
+val write_to_channel: (Buffer.t -> 'a -> unit) -> out_channel -> 'a -> unit
+val string_of_write: (Buffer.t -> 'a -> unit) -> ?len:int -> 'a -> string
 
 val read_of_string:
   (Yojson.Basic.lexer_state -> Lexing.lexbuf -> 'a) -> string -> 'a
@@ -22,7 +22,7 @@ val read_next_item :
   (Yojson.Basic.lexer_state -> Lexing.lexbuf -> 'a) ->
   (Yojson.Basic.lexer_state -> Lexing.lexbuf -> 'a)
 
-val write_comma: Bi_outbuf.t -> unit
+val write_comma: Buffer.t -> unit
 
 (** Jsonify simple types *)
 
@@ -46,7 +46,7 @@ val to_option: (Yojson.Basic.t -> 'a) -> Yojson.Basic.t -> 'a option
 (** Beware: `Null is reserved for None *)
 
 val write_option:
-  (Bi_outbuf.t -> 'a -> unit) -> Bi_outbuf.t -> 'a option -> unit
+  (Buffer.t -> 'a -> unit) -> Buffer.t -> 'a option -> unit
 
 val read_option:
   (Yojson.Basic.lexer_state -> Lexing.lexbuf -> 'a) ->
@@ -57,16 +57,16 @@ val of_list: ('a -> Yojson.Basic.t) -> 'a list -> Yojson.Basic.t
 val to_list:
   ?error_msg:string -> (Yojson.Basic.t -> 'a) -> Yojson.Basic.t -> 'a list
 
-val write_list: (Bi_outbuf.t -> 'a -> unit) -> Bi_outbuf.t -> 'a list -> unit
+val write_list: (Buffer.t -> 'a -> unit) -> Buffer.t -> 'a list -> unit
 
 val of_array: ('a -> Yojson.Basic.t) -> 'a array -> Yojson.Basic.t
 
 val to_array:
   ?error_msg:string -> (Yojson.Basic.t -> 'a) -> Yojson.Basic.t -> 'a array
 
-val write_array: (Bi_outbuf.t -> 'a -> unit) -> Bi_outbuf.t -> 'a array -> unit
+val write_array: (Buffer.t -> 'a -> unit) -> Buffer.t -> 'a array -> unit
 
-val write_sequence: Bi_outbuf.t -> (Bi_outbuf.t -> unit) list -> unit
+val write_sequence: Buffer.t -> (Buffer.t -> unit) list -> unit
 
 val read_variant:
   (Yojson.Basic.lexer_state -> Lexing.lexbuf -> 'a) ->
@@ -84,7 +84,7 @@ val to_assoc:
   Yojson.Basic.t -> 'a list
 
 val write_field:
-  string -> (Bi_outbuf.t -> 'a -> unit) -> Bi_outbuf.t -> 'a -> unit
+  string -> (Buffer.t -> 'a -> unit) -> Buffer.t -> 'a -> unit
 
 val of_pair:
   ?lab1:string -> ?lab2:string ->
@@ -97,8 +97,8 @@ val to_pair:
   Yojson.Basic.t -> 'a * 'b
 
 val write_compact_pair:
-  (Bi_outbuf.t -> 'a -> unit) -> (Bi_outbuf.t -> 'b -> unit) ->
-  Bi_outbuf.t -> 'a * 'b -> unit
+  (Buffer.t -> 'a -> unit) -> (Buffer.t -> 'b -> unit) ->
+  Buffer.t -> 'a * 'b -> unit
 
 val read_compact_pair:
   (Yojson.Basic.lexer_state -> Lexing.lexbuf -> 'a) ->

--- a/core/dataStructures/locality.ml
+++ b/core/dataStructures/locality.ml
@@ -135,12 +135,12 @@ let annot_of_yojson ?filenames f = function
   | `Assoc [ "val", x ] -> (f x, dummy)
   | x -> raise (Yojson.Basic.Util.Type_error ("Invalid location",x))
 
-let write_range ob f = Yojson.Basic.to_outbuf ob (to_compact_yojson None f)
+let write_range ob f = Yojson.Basic.to_buffer ob (to_compact_yojson None f)
 
 let string_of_range ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
+  let ob = Buffer.create len in
   write_range ob x;
-  Bi_outbuf.contents ob
+  Buffer.contents ob
 
 let read_range p lb =
   of_compact_yojson

--- a/core/dataStructures/locality.mli
+++ b/core/dataStructures/locality.mli
@@ -41,12 +41,12 @@ val annot_to_yojson :
   ?filenames : int Mods.StringMap.t ->
   ('a -> Yojson.Basic.t) -> 'a annot -> Yojson.Basic.t
 
-val write_position : Bi_outbuf.t -> position -> unit
+val write_position : Buffer.t -> position -> unit
 
 val read_position :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> position
 
-val write_range : Bi_outbuf.t -> t -> unit
+val write_range : Buffer.t -> t -> unit
   (** Output a JSON value of type {!t}. *)
 
 val string_of_range : ?len:int -> t -> string

--- a/core/dataStructures/nbr.ml
+++ b/core/dataStructures/nbr.ml
@@ -187,12 +187,12 @@ let of_yojson = function
   | x -> raise (Yojson.Basic.Util.Type_error ("Not an Nbr",x))
 
 let write_t ob f =
-  Yojson.Basic.to_outbuf ob (to_yojson f)
+  Yojson.Basic.to_buffer ob (to_yojson f)
 
 let string_of_t ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
+  let ob = Buffer.create len in
   write_t ob x;
-  Bi_outbuf.contents ob
+  Buffer.contents ob
 
 let read_t p lb =
   of_yojson (Yojson.Basic.from_lexbuf ~stream:true p lb)

--- a/core/dataStructures/nbr.mli
+++ b/core/dataStructures/nbr.mli
@@ -62,7 +62,7 @@ val to_yojson : t -> Yojson.Basic.t
 val of_yojson : Yojson.Basic.t -> t
 (** @raise Yojson.Basic.Util.Type_error if incorrect *)
 
-val write_t : Bi_outbuf.t -> t -> unit
+val write_t : Buffer.t -> t -> unit
 (** Output a JSON value of type {!t}. *)
 
 val string_of_t : ?len:int -> t -> string

--- a/core/dataStructures/result_util.mli
+++ b/core/dataStructures/result_util.mli
@@ -23,21 +23,21 @@ type ('a,'b) t = {
   messages : message list;
 }
 
-val write_message : Bi_outbuf.t -> message -> unit
+val write_message : Buffer.t -> message -> unit
 
 val read_message : Yojson.Safe.lexer_state -> Lexing.lexbuf -> message
 
 val print_message : Format.formatter -> message -> unit
 
 val write_t :
-  (Bi_outbuf.t -> 'ok -> unit) ->
-  (Bi_outbuf.t -> 'error -> unit) ->
-  Bi_outbuf.t -> ('ok, 'error) t -> unit
+  (Buffer.t -> 'ok -> unit) ->
+  (Buffer.t -> 'error -> unit) ->
+  Buffer.t -> ('ok, 'error) t -> unit
 (** Output a JSON value of type {!t}. *)
 
 val string_of_t :
-  (Bi_outbuf.t -> 'ok -> unit) ->
-  (Bi_outbuf.t -> 'error -> unit) ->
+  (Buffer.t -> 'ok -> unit) ->
+  (Buffer.t -> 'error -> unit) ->
   ?len:int -> ('ok, 'error) t -> string
 (** Serialize a value of type {!t} into a JSON string.  @param len
     specifies the initial length of the buffer used internally.

--- a/core/grammar/ast.mli
+++ b/core/grammar/ast.mli
@@ -186,5 +186,5 @@ val to_created_mixture : mixture -> mixture
 val compil_of_json : Yojson.Basic.t -> parsing_compil
 val compil_to_json : parsing_compil -> Yojson.Basic.t
 
-val write_parsing_compil : Bi_outbuf.t -> parsing_compil -> unit
+val write_parsing_compil : Buffer.t -> parsing_compil -> unit
 val read_parsing_compil : Yojson.lexer_state -> Lexing.lexbuf -> parsing_compil

--- a/core/grammar/kfiles.ml
+++ b/core/grammar/kfiles.ml
@@ -25,11 +25,11 @@ type catalog_item = {
 }
 
 let write_catalog_item ob { position; id } =
-  let () = Bi_outbuf.add_char ob '{' in
+  let () = Buffer.add_char ob '{' in
   let () = JsonUtil.write_field "id" Yojson.Basic.write_string ob id in
   let () = JsonUtil.write_comma ob in
   let () = JsonUtil.write_field "position" Yojson.Basic.write_int ob position in
-  Bi_outbuf.add_char ob '}'
+  Buffer.add_char ob '}'
 
 let read_catalog_item p lb =
   let (position,id,count) =

--- a/core/grammar/kfiles.mli
+++ b/core/grammar/kfiles.mli
@@ -13,7 +13,7 @@ type catalog_item = {
   id : string;
 }
 
-val write_catalog_item : Bi_outbuf.t -> catalog_item -> unit
+val write_catalog_item : Buffer.t -> catalog_item -> unit
 val read_catalog_item : Yojson.lexer_state -> Lexing.lexbuf -> catalog_item
 
 val create : unit -> catalog

--- a/core/simulation/counter.ml
+++ b/core/simulation/counter.ml
@@ -31,7 +31,7 @@ module Efficiency : sig
   val incr_time_correction : t -> t
   val incr_consecutive_blocked : t -> t
 
-  val write_t : Bi_outbuf.t -> t -> unit
+  val write_t : Buffer.t -> t -> unit
   val string_of_t : ?len:int -> t -> string
   val read_t : Yojson.Safe.lexer_state -> Lexing.lexbuf -> t
   val t_of_string : string -> t
@@ -138,12 +138,12 @@ end =
         raise (Yojson.Basic.Util.Type_error ("Invalid simulation efficiency",x))
 
     let write_t ob f =
-      Yojson.Basic.to_outbuf ob (to_yojson f)
+      Yojson.Basic.to_buffer ob (to_yojson f)
 
     let string_of_t ?(len = 1024) x =
-      let ob = Bi_outbuf.create len in
+      let ob = Buffer.create len in
       write_t ob x;
-      Bi_outbuf.contents ob
+      Buffer.contents ob
 
     let read_t p lb =
       of_yojson (Yojson.Basic.from_lexbuf ~stream:true p lb)

--- a/core/simulation/counter.mli
+++ b/core/simulation/counter.mli
@@ -18,7 +18,7 @@ module Efficiency : sig
       mutable time_correction : int
     }
 
-  val write_t : Bi_outbuf.t -> t -> unit
+  val write_t : Buffer.t -> t -> unit
   (** Output a JSON value of type {!t}. *)
 
   val string_of_t : ?len:int -> t -> string

--- a/core/simulation/data.ml
+++ b/core/simulation/data.ml
@@ -82,7 +82,7 @@ let print_dot_snapshot ?uuid f s =
     s.snapshot_tokens
 
 let write_snapshot ob s =
-  let () = Bi_outbuf.add_char ob '{' in
+  let () = Buffer.add_char ob '{' in
   let () = JsonUtil.write_field
       "snapshot_event" Yojson.Basic.write_int ob s.snapshot_event in
   let () = JsonUtil.write_comma ob in
@@ -101,7 +101,7 @@ let write_snapshot ob s =
       (JsonUtil.write_array
          (JsonUtil.write_compact_pair Yojson.Basic.write_string Nbr.write_t))
       ob s.snapshot_tokens in
-  Bi_outbuf.add_char ob '}'
+  Buffer.add_char ob '}'
 
 let read_snapshot p lb =
   let snapshot_event,snapshot_time,snapshot_agents,snapshot_tokens =
@@ -141,7 +141,7 @@ type din = {
 }
 
 let write_din ob f =
-  let () = Bi_outbuf.add_char ob '{' in
+  let () = Buffer.add_char ob '{' in
   let () = JsonUtil.write_field
       "din_kind" Primitives.write_din_kind ob f.din_data.din_kind in
   let () = JsonUtil.write_comma ob in
@@ -160,7 +160,7 @@ let write_din ob f =
   let () = JsonUtil.write_field "din_fluxs"
       (JsonUtil.write_array (JsonUtil.write_array Yojson.Basic.write_float))
       ob f.din_data.din_fluxs in
-  Bi_outbuf.add_char ob '}'
+  Buffer.add_char ob '}'
 
 let read_din p lb =
   let (din_kind,din_start,din_hits,din_fluxs,din_rules,din_end) =
@@ -299,7 +299,7 @@ let init_plot env =
   { plot_legend; plot_series = []; }
 
 let write_plot ob f =
-  let () = Bi_outbuf.add_char ob '{' in
+  let () = Buffer.add_char ob '{' in
   let () = JsonUtil.write_field "legend"
       (JsonUtil.write_array Yojson.Basic.write_string) ob f.plot_legend in
   let () = JsonUtil.write_comma ob in
@@ -307,7 +307,7 @@ let write_plot ob f =
       (JsonUtil.write_list (JsonUtil.write_array
                               (JsonUtil.write_option Yojson.Basic.write_float)))
       ob f.plot_series in
-  Bi_outbuf.add_char ob '}'
+  Buffer.add_char ob '}'
 
 let read_plot p lb =
   let (plot_legend,plot_series) =

--- a/core/simulation/data.mli
+++ b/core/simulation/data.mli
@@ -46,7 +46,7 @@ val print_snapshot : ?uuid: int -> Format.formatter -> snapshot -> unit
 val print_dot_snapshot : ?uuid: int -> Format.formatter -> snapshot -> unit
 
 val write_snapshot :
-  Bi_outbuf.t -> snapshot -> unit
+  Buffer.t -> snapshot -> unit
   (** Output a JSON value of type {!snapshot}. *)
 
 val string_of_snapshot :
@@ -69,7 +69,7 @@ val print_dot_din : ?uuid: int -> Format.formatter -> din -> unit
 
 val print_html_din : Format.formatter -> din -> unit
 
-val write_din : Bi_outbuf.t -> din -> unit
+val write_din : Buffer.t -> din -> unit
   (** Output a JSON value of type {!din}. *)
 
 val string_of_din : ?len:int -> din -> string
@@ -94,7 +94,7 @@ val add_plot_line : Nbr.t array -> plot -> plot
 
 val init_plot : Model.t -> plot
 
-val write_plot : Bi_outbuf.t -> plot -> unit
+val write_plot : Buffer.t -> plot -> unit
   (** Output a JSON value of type {!plot}. *)
 
 val string_of_plot : ?len:int -> plot -> string

--- a/core/simulation/trace.ml
+++ b/core/simulation/trace.ml
@@ -337,9 +337,9 @@ let write_json = JsonUtil.write_list write_step
 let read_json st b = List.rev (Yojson.Basic.read_list_rev read_step st b)
 
 let string_of_step ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
+  let ob = Buffer.create len in
   write_step ob x;
-  Bi_outbuf.contents ob
+  Buffer.contents ob
 
 let step_of_string s =
   read_step (Yojson.Safe.init_lexer ()) (Lexing.from_string s)

--- a/core/simulation/trace.mli
+++ b/core/simulation/trace.mli
@@ -96,7 +96,7 @@ val step_to_yojson : step -> Yojson.Basic.t
 
 val json_dictionnary : string
 
-val write_step : Bi_outbuf.t -> step -> unit
+val write_step : Buffer.t -> step -> unit
   (** Output a JSON value of type {!step}. *)
 
 val string_of_step : ?len:int -> step -> string
@@ -112,7 +112,7 @@ val read_step :
 val step_of_string : string -> step
   (** Deserialize JSON data of type {!step}. *)
 
-val write_json : Bi_outbuf.t -> t -> unit
+val write_json : Buffer.t -> t -> unit
 val read_json : Yojson.Safe.lexer_state -> Lexing.lexbuf -> t
 
 val init_trace_file : uuid:int -> Model.t -> out_channel -> unit

--- a/core/siteGraphs/agent.mli
+++ b/core/siteGraphs/agent.mli
@@ -28,7 +28,7 @@ val print_raw_internal :
 val rename : debugMode:bool -> Renaming.t -> t -> t
 
 val json_dictionnary : string
-val write_json : Bi_outbuf.t -> t -> unit
+val write_json : Buffer.t -> t -> unit
 val read_json : Yojson.Basic.lexer_state -> Lexing.lexbuf -> t
 val to_json : t -> Yojson.Basic.t
 val of_json : Yojson.Basic.t -> t

--- a/core/siteGraphs/user_graph.ml
+++ b/core/siteGraphs/user_graph.ml
@@ -178,17 +178,17 @@ type connected_component = cc_node array
  *)
 
 let write_cc_port ob p =
-  let () = Bi_outbuf.add_char ob '{' in
+  let () = Buffer.add_char ob '{' in
   let () = JsonUtil.write_field
       "port_links" (fun ob -> function
           | WHATEVER -> Yojson.Basic.write_null ob ()
           | SOME -> Yojson.Basic.write_bool ob true
           | TYPE (si,ty) ->
-            let () = Bi_outbuf.add_string ob "{\"site_name\":\"" in
-            let () = Bi_outbuf.add_string ob si in
-            let () = Bi_outbuf.add_string ob "\",\"agent_type\":\"" in
-            let () = Bi_outbuf.add_string ob ty in
-            Bi_outbuf.add_string ob "\"}"
+            let () = Buffer.add_string ob "{\"site_name\":\"" in
+            let () = Buffer.add_string ob si in
+            let () = Buffer.add_string ob "\",\"agent_type\":\"" in
+            let () = Buffer.add_string ob ty in
+            Buffer.add_string ob "\"}"
           | LINKS l ->
             JsonUtil.write_list
               (JsonUtil.write_compact_pair
@@ -201,28 +201,28 @@ let write_cc_port ob p =
       "port_states"
       (JsonUtil.write_option (JsonUtil.write_list Yojson.Basic.write_string))
       ob p.port_states in
-  Bi_outbuf.add_char ob '}'
+  Buffer.add_char ob '}'
 
 let write_site ob f =
-  let () = Bi_outbuf.add_char ob '[' in
+  let () = Buffer.add_char ob '[' in
   let () = match f.site_type with
     | Counter i ->
       let () = Yojson.Basic.write_string ob "counter" in
-      let () = Bi_outbuf.add_char ob ',' in
+      let () = Buffer.add_char ob ',' in
       Yojson.Basic.write_int ob i
     | Port p ->
       let () = Yojson.Basic.write_string ob "port" in
-      let () = Bi_outbuf.add_char ob ',' in
+      let () = Buffer.add_char ob ',' in
       write_cc_port ob p in
-  Bi_outbuf.add_char ob ']'
+  Buffer.add_char ob ']'
 
 let write_cc_site ob f =
-  let () = Bi_outbuf.add_char ob '{' in
+  let () = Buffer.add_char ob '{' in
   let () = JsonUtil.write_field
       "site_name" Yojson.Basic.write_string ob f.site_name in
   let () = JsonUtil.write_comma ob in
   let () = JsonUtil.write_field "site_type" write_site ob f in
-  Bi_outbuf.add_char ob '}'
+  Buffer.add_char ob '}'
 
 let links_of_yojson = function
   | `Null -> WHATEVER
@@ -277,7 +277,7 @@ let read_cc_site p lb =
 let write_cc_node ob x =
   JsonUtil.write_option
     (fun ob f ->
-       let () = Bi_outbuf.add_char ob '{' in
+       let () = Buffer.add_char ob '{' in
        let () = JsonUtil.write_field
            "node_type" Yojson.Basic.write_string ob f.node_type in
        let () = JsonUtil.write_comma ob in
@@ -289,7 +289,7 @@ let write_cc_node ob x =
            JsonUtil.write_comma ob in
        let () = JsonUtil.write_field
            "node_sites" (JsonUtil.write_array write_cc_site) ob f.node_sites in
-       Bi_outbuf.add_char ob '}')
+       Buffer.add_char ob '}')
     ob x
 
 let read_cc_node p lb =
@@ -313,9 +313,9 @@ let read_connected_component ob f =
   Yojson.Basic.read_array (Yojson.Basic.read_array read_cc_node) ob f
 
 let string_of_connected_component ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
+  let ob = Buffer.create len in
   let () = write_connected_component ob x in
-  Bi_outbuf.contents ob
+  Buffer.contents ob
 
 let connected_component_of_string s =
   read_connected_component (Yojson.Safe.init_lexer ()) (Lexing.from_string s)

--- a/core/siteGraphs/user_graph.mli
+++ b/core/siteGraphs/user_graph.mli
@@ -42,7 +42,7 @@ val print_dot_cc : int -> Format.formatter -> connected_component -> unit
 val links_of_yojson : Yojson.Basic.t -> links
 
 val write_connected_component :
-  Bi_outbuf.t -> connected_component -> unit
+  Buffer.t -> connected_component -> unit
   (** Output a JSON value of type {!connected_component}. *)
 
 val string_of_connected_component :

--- a/core/term/instantiation.mli
+++ b/core/term/instantiation.mli
@@ -123,7 +123,7 @@ val json_dictionnary : string
 
 val test_to_json : ('a -> Yojson.Basic.t) -> 'a test -> Yojson.Basic.t
 val test_of_json : (Yojson.Basic.t -> 'a) -> Yojson.Basic.t -> 'a test
-val write_test : (Bi_outbuf.t -> 'a -> unit) -> Bi_outbuf.t -> 'a test -> unit
+val write_test : (Buffer.t -> 'a -> unit) -> Buffer.t -> 'a test -> unit
 val read_test :
   (Yojson.Basic.lexer_state -> Lexing.lexbuf -> 'a) ->
   Yojson.Basic.lexer_state -> Lexing.lexbuf -> 'a test
@@ -131,13 +131,13 @@ val read_test :
 val action_to_json : ('a -> Yojson.Basic.t) -> 'a action -> Yojson.Basic.t
 val action_of_json : (Yojson.Basic.t -> 'a) -> Yojson.Basic.t -> 'a action
 val write_action :
-  (Bi_outbuf.t -> 'a -> unit) -> Bi_outbuf.t -> 'a action -> unit
+  (Buffer.t -> 'a -> unit) -> Buffer.t -> 'a action -> unit
 val read_action :
   (Yojson.Basic.lexer_state -> Lexing.lexbuf -> 'a) ->
   Yojson.Basic.lexer_state -> Lexing.lexbuf -> 'a action
 val event_to_json : ('a -> Yojson.Basic.t) -> 'a event -> Yojson.Basic.t
 val event_of_json : (Yojson.Basic.t -> 'a) -> Yojson.Basic.t -> 'a event
-val write_event : (Bi_outbuf.t -> 'a -> unit) -> Bi_outbuf.t -> 'a event -> unit
+val write_event : (Buffer.t -> 'a -> unit) -> Buffer.t -> 'a event -> unit
 val read_event :
   (Yojson.Basic.lexer_state -> Lexing.lexbuf -> 'a) ->
   Yojson.Basic.lexer_state -> Lexing.lexbuf -> 'a event

--- a/core/term/pattern.mli
+++ b/core/term/pattern.mli
@@ -164,7 +164,7 @@ type sharing_level = No_sharing | Compatible_patterns | Max_sharing
 (** Heuristic to use on domain construction *)
 
 val write_sharing_level :
-  Bi_outbuf.t -> sharing_level -> unit
+  Buffer.t -> sharing_level -> unit
   (** Output a JSON value of type {!sharing_level}. *)
 
 val string_of_sharing_level :

--- a/core/term/primitives.ml
+++ b/core/term/primitives.ml
@@ -395,12 +395,12 @@ let din_kind_of_yojson = function
            (Yojson.Basic.Util.Type_error ("Incorrect din_kind",x))
 
 let write_din_kind ob f =
-  Yojson.Basic.to_outbuf ob (din_kind_to_yojson f)
+  Yojson.Basic.to_buffer ob (din_kind_to_yojson f)
 
 let string_of_din_kind ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
+  let ob = Buffer.create len in
   write_din_kind ob x;
-  Bi_outbuf.contents ob
+  Buffer.contents ob
 
 let read_din_kind p lb =
   din_kind_of_yojson (Yojson.Basic.from_lexbuf ~stream:true p lb)

--- a/core/term/primitives.mli
+++ b/core/term/primitives.mli
@@ -102,7 +102,7 @@ val din_kind_to_yojson : din_kind -> Yojson.Basic.t
 val din_kind_of_yojson : Yojson.Basic.t -> din_kind
 
 val write_din_kind :
-  Bi_outbuf.t -> din_kind -> unit
+  Buffer.t -> din_kind -> unit
   (** Output a JSON value of type {!din_kind}. *)
 
 val string_of_din_kind :


### PR DESCRIPTION
This should make Kappa compatible with the latest version of yojson.

Since https://github.com/ocaml-community/yojson/pull/74, yojson does not rely on biniou buffers.

The main drawback seems to be that `JsonUtil.write_to_channel` now writes everything to the memory (in a `Buffer.t`) before dumping the buffer to the channel.