### PR TITLE
Update kappa-library.opam

### DIFF
--- a/kappa-library.opam
+++ b/kappa-library.opam
@@ -16,7 +16,7 @@ depends : [
   "num"
   "re"
   "dune"
-  "yojson" { >= "1.6.0" }
+  "yojson" { >= "2.0" }
   "lwt" { >= "4.2.0" }
   "stdlib-shims"
   "fmt"


### PR DESCRIPTION
KaSim now requires Yojson 2 and so the proper lower bound should be specified in the opam file.