### PR TITLE
Add > as syntactic sugar for >= in counters

### DIFF
--- a/core/KaSa_rep/frontend/prepreprocess.ml
+++ b/core/KaSa_rep/frontend/prepreprocess.ml
@@ -342,6 +342,7 @@ let translate_counter_test test =
   match test with
   | Ast.CEQ i -> Ckappa_sig.CEQ i
   | Ast.CGTE i -> Ckappa_sig.CGTE i
+  | Ast.CGT i -> Ckappa_sig.CGTE (i+1)
   | Ast.CVAR x -> Ckappa_sig.CVAR x
 
 let fst_opt a_opt =

--- a/core/grammar/ast.ml
+++ b/core/grammar/ast.ml
@@ -23,7 +23,7 @@ type port = {
   port_lnk_mod: int Locality.annot option option;
 }
 
-type counter_test = CEQ of int | CGTE of int | CVAR of string
+type counter_test = CEQ of int | CGTE of int | CGT of int | CVAR of string
 
 type counter = {
   count_nme: string Locality.annot;
@@ -244,6 +244,7 @@ let print_ast_port f p =
 let print_counter_test f = function
   | CEQ x, _ -> Format.fprintf f "=%i" x
   | CGTE x, _ -> Format.fprintf f ">=%i" x
+  | CGT x, _ -> Format.fprintf f ">%i" x
   | CVAR x, _ ->  Format.fprintf f "=%s" x
 
 let print_counter_delta test f (delta,_) =
@@ -278,12 +279,15 @@ let string_option_annot_of_json filenames =
 let counter_test_to_json = function
   | CEQ x -> `Assoc [ "test", `String "eq"; "val", `Int x ]
   | CGTE x -> `Assoc [ "test", `String "gte"; "val", `Int x ]
+  | CGT x -> `Assoc [ "test", `String "gt"; "val", `Int x ]
   | CVAR x -> `Assoc [ "test", `String "eq"; "val", `String x ]
 let counter_test_of_json = function
   | `Assoc [ "test", `String "eq"; "val", `Int x ]
   | `Assoc [ "val", `Int x; "test", `String "eq" ] -> CEQ x
   | `Assoc [ "val", `Int x; "test", `String "gte" ]
   | `Assoc [ "test", `String "gte"; "val", `Int x ] -> CGTE x
+  | `Assoc [ "val", `Int x; "test", `String "gt" ]
+  | `Assoc [ "test", `String "gt"; "val", `Int x ] -> CGT x
   | `Assoc [ "test", `String "eq"; "val", `String x ]
   | `Assoc [ "val", `String x; "test", `String "eq" ] -> CVAR x
   | x ->

--- a/core/grammar/ast.mli
+++ b/core/grammar/ast.mli
@@ -21,7 +21,7 @@ type port = {
   port_lnk_mod: int Locality.annot option option;
 }
 
-type counter_test = CEQ of int | CGTE of int | CVAR of string
+type counter_test = CEQ of int | CGTE of int | CGT of int | CVAR of string
 
 type counter = {
   count_nme: string Locality.annot;

--- a/core/grammar/kparser4.mly
+++ b/core/grammar/kparser4.mly
@@ -129,6 +129,7 @@ counter_modif:
 counter_test:
   | EQUAL annot INT { (Ast.CEQ $3,rhs_pos 3) }
   | GREATER annot EQUAL annot INT { (Ast.CGTE $5,rhs_pos 5) }
+  | GREATER annot INT { (Ast.CGT $3,rhs_pos 3) }
   | EQUAL annot ID { (Ast.CVAR $3,rhs_pos 3) }
   ;
 

--- a/core/grammar/lKappa_compiler.ml
+++ b/core/grammar/lKappa_compiler.ml
@@ -1277,6 +1277,9 @@ let create_t sites incr_info =
              | Ast.CGTE _ ->
                 raise (ExceptionDefn.Internal_Error
                          ("Counter should not have >= in signature",pos))
+             | Ast.CGT _ ->
+                raise (ExceptionDefn.Internal_Error
+                         ("Counter should not have > in signature",pos))
              | Ast.CEQ j ->
                 (c.Ast.count_nme,
                 (NamedDecls.create [||],

--- a/tests/integration/compiler/counters_greater_than/README
+++ b/tests/integration/compiler/counters_greater_than/README
@@ -1,0 +1,1 @@
+"${KAPPABIN}"KaSim -l 1 -seed 442310228 -d output counters_greater_than.ka -syntax 4 || true

--- a/tests/integration/compiler/counters_greater_than/counters_greater_than.ka
+++ b/tests/integration/compiler/counters_greater_than/counters_greater_than.ka
@@ -1,0 +1,13 @@
+%agent:	A(c{=0 / +=3})
+
+%init: 1 A(c{=0})
+%init: 1 A(c{=1})
+%init: 1 A(c{=2})
+
+'greater_than_edit' A(c{>0/+=1}) @ 1
+
+'greater_than_arrow' A(c{>0}) -> A(c{+=1}) @ 1
+ 
+%obs: A1 |A(c{=0})|
+%obs: A2 |A(c{>0})|
+%obs: A3 |A(c{>=0})|

--- a/tests/integration/compiler/counters_greater_than/output/LOG.ref
+++ b/tests/integration/compiler/counters_greater_than/output/LOG.ref
@@ -1,0 +1,21 @@
+Parsing counters_greater_than.ka...
+done
++ simulation parameters
++ Sanity checks
++ Compiling...
++ Building initial simulation conditions...
+	 -variable declarations
+	 -rules
+	 -interventions
+	 -observables
+	 -update_domain construction
+	 9 (sub)observables 5 navigation steps
+	 -initial conditions
++ Building initial state (9 agents)
+Done
++ Command line to rerun is: 'KaSim' '-l' '1' '-seed' '442310228' '-d' 'output' 'counters_greater_than.ka' '-syntax' '4'
+______________________________________________________________________
+#################
+Counter c of agent A reached maximum
+#####################################################
+Simulation ended

--- a/tests/integration/compiler/counters_greater_than/output/counter_perturbation.ka.ref
+++ b/tests/integration/compiler/counters_greater_than/output/counter_perturbation.ka.ref
@@ -1,0 +1,7 @@
+// Snapshot [Event: 3]
+%def: "T0" "0.35709268540166106"
+
+%init: 1 /*1 agents*/ A(c{=4})
+%init: 1 /*1 agents*/ A(c{=2})
+%init: 1 /*1 agents*/ A(c{=0})
+

--- a/tests/integration/compiler/counters_greater_than/output/data.csv.ref
+++ b/tests/integration/compiler/counters_greater_than/output/data.csv.ref
@@ -1,0 +1,3 @@
+# Output of 'KaSim' '-l' '1' '-seed' '442310228' '-d' 'output' 'counters_greater_than.ka' '-syntax' '4'
+"[T]","A1","A2","A3"
+0.,1,2,3

--- a/tests/integration/compiler/counters_greater_than/output/inputs.ka.ref
+++ b/tests/integration/compiler/counters_greater_than/output/inputs.ka.ref
@@ -1,0 +1,29 @@
+%def: "seed" "442310228"
+%def: "dumpIfDeadlocked" "true"
+%def: "maxConsecutiveClash" "3"
+%def: "progressBarSize" "70"
+%def: "progressBarSymbol" "#"
+%def: "plotPeriod" "1" "t.u."
+%def: "outputFileName" "data.csv"
+
+
+%agent: A(c{=0/+=3})
+
+%var:/*0*/ 'A1' |A(c{=0})|
+%var:/*1*/ 'A2' |A(c{=1})|
+%var:/*2*/ 'A3' |A(c{=0})|
+%plot: [T]
+%plot: A1
+%plot: A2
+%plot: A3
+
+'greater_than_edit' A(c{>=1/+=1}) @ 1
+'greater_than_arrow' A(c{>=1/+=1}) @ 1
+
+/*0*/%mod: (|A(c{=4})| = 1) do $PRINTF ""; $PRINTF "Counter c of agent A reached maximum"; $STOP "counter_perturbation.ka"; repeat [false]
+
+%init: 1 A(c{=0})
+%init: 1 A(c{=1})
+%init: 1 A(c{=2})
+
+%mod: [E] = 3 do $STOP;

--- a/tests/integration/compiler/site_mismatch/output/LOG.ref
+++ b/tests/integration/compiler/site_mismatch/output/LOG.ref
@@ -73,4 +73,4 @@ every agent may occur in the model
 ------------------------------------------------------------
 
 Some exceptions have been raised
-error: file_name: core/KaSa_rep/frontend/prepreprocess.ml; message: line 840, File "crash.ka", line 4, characters 5-69:: missaligned rule: the rule is ignored; exception:Exit
+error: file_name: core/KaSa_rep/frontend/prepreprocess.ml; message: line 841, File "crash.ka", line 4, characters 5-69:: missaligned rule: the rule is ignored; exception:Exit


### PR DESCRIPTION
This patch adds support for greater-than (>) as syntactic sugar for greater-than-or-equal (>=).

This patch is a precursor for an upcoming patch to add less-than-or-equal (<=) to counters. I am sending this smaller patch first to confirm that my approach & style is correct, and that I haven't missed any important code features, because the less-than-or-equal patch will be similar but larger.