### PR TITLE
Ignore Python build outputs and temporary integration test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ js/external
 todo.org
 *~
 _build/
+/build/
 .merlin
 ._d/
 ._ncdi/
@@ -56,7 +57,7 @@ site
 # python
 *.pyc
 dist/
-python/*.egg-info
+*.egg-info
 .idea
 
 # eclipse

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,11 @@ models/test_suite/error
 models/test_suite/*/*/output/profiling.txt
 models/test_suite/*/*/output/profiling.html
 models/test_suite/*/*/output/compression_status.txt
+/tests/integration/error
+/tests/integration/*/*/error
+# Ignore all test outputs except the reference files.
+/tests/integration/*/*/output/*
+!/tests/integration/*/*/output/*.ref
 
 # generated code
 site


### PR DESCRIPTION
This PR contains 2 commits:
- One ignores a directory called `build` at the project root (`/build/`) and `.egg-info` directories anywhere in the repository.
- The other ignores `error` files under `tests/integration`, and all `outputs` except `.ref` files using [gitignore's `!` syntax](https://git-scm.com/docs/gitignore).