### PR TITLE
Print greater-than-equal as >= for inputs.ka

### DIFF
--- a/tests/integration/compiler/counters/counters.ka
+++ b/tests/integration/compiler/counters/counters.ka
@@ -44,3 +44,4 @@
 
 //counter in obs
 %obs: 'A1' |A(x{u}[.],c{>=1})|
+%obs: 'A2' |A(x{u}[.],c{=1})|

--- a/tests/integration/compiler/counters/output/LOG.ref
+++ b/tests/integration/compiler/counters/output/LOG.ref
@@ -9,7 +9,7 @@ done
 	 -interventions
 	 -observables
 	 -update_domain construction
-	 50 (sub)observables 175 navigation steps
+	 52 (sub)observables 176 navigation steps
 	 -initial conditions
 + Building initial state (60 agents)
 Done

--- a/tests/integration/compiler/counters/output/data.csv.ref
+++ b/tests/integration/compiler/counters/output/data.csv.ref
@@ -1,4 +1,4 @@
 # Output of 'KaSim' '-l' '1' '-seed' '442310228' '-d' 'output' 'counters.ka' '-syntax' '4'
-"[T]","A1"
-0.,0
-1.,2
+"[T]","A1","A2"
+0.,0,0
+1.,2,2

--- a/tests/integration/compiler/counters/output/inputs.ka.ref
+++ b/tests/integration/compiler/counters/output/inputs.ka.ref
@@ -10,9 +10,11 @@
 %agent: A(x{u p}[x.B] c{=0/+=3} d{=1/+=2})
 %agent: B(x[x.A] c{=0/+=3})
 
-%var:/*0*/ 'A1' |A(x{u}[.] c{=1})|
+%var:/*0*/ 'A1' |A(x{u}[.] c{>=1})|
+%var:/*1*/ 'A2' |A(x{u}[.] c{=1})|
 %plot: [T]
 %plot: A1
+%plot: A2
 
 'r1' B(x[./1]), A(x[./1]) @ 1
 'r2__320' B(x[./1] c{=3}), A(x[./1] c{=0} d{=2}) @ (((3 + 2) + 0) * 0.1)
@@ -65,9 +67,9 @@
 'r15' A(x{u}[.] c{=2} d[#])-, A(x{u}[.] c{>=1}) @ 1
 'r16' A(x{u}[.] c{=2} d[#])-, A(x{u}[.] c{=1} d{=1})+ @ 1
 
-/*0*/%mod: (|B(c{=4})| = 1) do $PRINTF ""; $PRINTF "Counter c of agent B reached maximum"; $STOP "counter_perturbation.ka"; repeat [false]
-/*1*/%mod: (|A(d{=3})| = 1) do $PRINTF ""; $PRINTF "Counter d of agent A reached maximum"; $STOP "counter_perturbation.ka"; repeat [false]
-/*2*/%mod: (|A(c{=4})| = 1) do $PRINTF ""; $PRINTF "Counter c of agent A reached maximum"; $STOP "counter_perturbation.ka"; repeat [false]
+/*0*/%mod: (|B(c{>=4})| = 1) do $PRINTF ""; $PRINTF "Counter c of agent B reached maximum"; $STOP "counter_perturbation.ka"; repeat [false]
+/*1*/%mod: (|A(d{>=3})| = 1) do $PRINTF ""; $PRINTF "Counter d of agent A reached maximum"; $STOP "counter_perturbation.ka"; repeat [false]
+/*2*/%mod: (|A(c{>=4})| = 1) do $PRINTF ""; $PRINTF "Counter c of agent A reached maximum"; $STOP "counter_perturbation.ka"; repeat [false]
 
 %init: 10 A(x{u}[.] c{=0} d{=1})
 %init: 10 B(x[.] c{=0})

--- a/tests/integration/compiler/counters_2_levels/output/inputs.ka.ref
+++ b/tests/integration/compiler/counters_2_levels/output/inputs.ka.ref
@@ -19,7 +19,7 @@ A(s1{p/u}[.] c{=2/+=-1}) @ (2 * (5 ^ 2))
 A(s2{p/u}[#] c{=1/+=-1}) @ (2 * (5 ^ 1))
 A(s2{p/u}[#] c{=2/+=-1}) @ (2 * (5 ^ 2))
 
-/*0*/%mod: (|A(c{=3})| = 1) do $PRINTF ""; $PRINTF "Counter c of agent A reached maximum"; $STOP "counter_perturbation.ka"; repeat [false]
+/*0*/%mod: (|A(c{>=3})| = 1) do $PRINTF ""; $PRINTF "Counter c of agent A reached maximum"; $STOP "counter_perturbation.ka"; repeat [false]
 
 %init: 40 A(s1{u}[.] s2{u}[.] c{=0})
 

--- a/tests/integration/compiler/counters_init_pert/output/inputs.ka.ref
+++ b/tests/integration/compiler/counters_init_pert/output/inputs.ka.ref
@@ -11,7 +11,7 @@
 
 %plot: [T]
 A(x{u/p}[.] c{>=0/+=1}) @ 1
-/*0*/%mod: (|A(c{=11})| = 1) do $PRINTF ""; $PRINTF "Counter c of agent A reached maximum"; $STOP "counter_perturbation.ka"; repeat [false]
+/*0*/%mod: (|A(c{>=11})| = 1) do $PRINTF ""; $PRINTF "Counter c of agent A reached maximum"; $STOP "counter_perturbation.ka"; repeat [false]
 /*1*/%mod: (|A(c{=2})| > 1) do $APPLY 10 A(x{u}[.] c{=1})+; repeat [false]
 
 %init: 10 A(x{u}[.] c{=1})

--- a/tests/integration/compiler/counters_perturbation/output/inputs.ka.ref
+++ b/tests/integration/compiler/counters_perturbation/output/inputs.ka.ref
@@ -13,7 +13,7 @@
 'r1' A(x[.] c{>=0/+=1}) @ 1
 'r2' A(x[.] c{>=1/+=1}) @ 10
 
-/*0*/%mod: (|A(c{=4})| = 1) do $PRINTF ""; $PRINTF "Counter c of agent A reached maximum"; $STOP "counter_perturbation.ka"; repeat [false]
+/*0*/%mod: (|A(c{>=4})| = 1) do $PRINTF ""; $PRINTF "Counter c of agent A reached maximum"; $STOP "counter_perturbation.ka"; repeat [false]
 
 %init: 40 A(x{u}[.] c{=0})
 

--- a/tests/integration/compiler/counters_signature_with_contact_map/output/inputs.ka.ref
+++ b/tests/integration/compiler/counters_signature_with_contact_map/output/inputs.ka.ref
@@ -14,9 +14,9 @@
 'r1' B(x[./1]), A(x[./1]) @ 1
 'r2' B(x[1/.] c{>=0/+=1}), A(x[1/.] c{>=0/+=1}) @ 1
 
-/*0*/%mod: (|B(c{=4})| = 1) do $PRINTF ""; $PRINTF "Counter c of agent B reached maximum"; $STOP "counter_perturbation.ka"; repeat [false]
-/*1*/%mod: (|A(d{=3})| = 1) do $PRINTF ""; $PRINTF "Counter d of agent A reached maximum"; $STOP "counter_perturbation.ka"; repeat [false]
-/*2*/%mod: (|A(c{=4})| = 1) do $PRINTF ""; $PRINTF "Counter c of agent A reached maximum"; $STOP "counter_perturbation.ka"; repeat [false]
+/*0*/%mod: (|B(c{>=4})| = 1) do $PRINTF ""; $PRINTF "Counter c of agent B reached maximum"; $STOP "counter_perturbation.ka"; repeat [false]
+/*1*/%mod: (|A(d{>=3})| = 1) do $PRINTF ""; $PRINTF "Counter d of agent A reached maximum"; $STOP "counter_perturbation.ka"; repeat [false]
+/*2*/%mod: (|A(c{>=4})| = 1) do $PRINTF ""; $PRINTF "Counter c of agent A reached maximum"; $STOP "counter_perturbation.ka"; repeat [false]
 
 %init: 10 A(x[.] c{=0} d{=1})
 %init: 10 B(x[.] c{=0})

--- a/tests/integration/kasa_preprocessing/counters/output/LOG.ref
+++ b/tests/integration/kasa_preprocessing/counters/output/LOG.ref
@@ -42,6 +42,8 @@ Compiling...
 Generating the raw contact map...
 Compilation:Compilation:variables:0:
 Compilation:variables:0:A1: 
+Compilation:variables:1:
+Compilation:variables:1:A2: 
 Compilation:agent definition:0:A:
 Compilation:agent definition:       File "../../compiler/counters/counters.ka", line 1, characters 8-9:
 Compilation:agent definition:       File "../../compiler/counters/counters.ka", line 4, characters 10-11:
@@ -977,9 +979,15 @@ Quarks:Var 0
 Quarks:var_id:0,agent_type:0
 Quarks:var_id:0,agent_type:0,site_type:0,state:0
 Quarks:var_id:0,agent_type:0,site_type:3,state:0
+Quarks:Var 1
+Quarks:var_id:1,agent_type:0
+Quarks:var_id:1,agent_type:0,site_type:0,state:0
+Quarks:var_id:1,agent_type:0,site_type:1,state:1
+Quarks:var_id:1,agent_type:0,site_type:3,state:0
 
 REMARKS: The notation [i] is a position of an agent in a rule/var. If a position is a negative number [-i], then it refers an agent that is connected to the agent at position (i-1) that is modified by side effects.
 Quarks:agent_var++**:agent_type:0,var:0->[0]
+Quarks:agent_var++**:agent_type:0,var:1->[0]
 Quarks:agent_test**:agent_type:0,rule:0->[0]
 Quarks:agent_test**:agent_type:0,rule:1->[0]
 Quarks:agent_test**:agent_type:0,rule:2->[0]
@@ -1013,7 +1021,10 @@ Quarks:agent_modif-:agent_type:0,rule:16->[0]
 Quarks:agent_modif-:agent_type:0,rule:17->[1]
 Quarks:agent_modif-:agent_type:0,rule:18->[1]
 Quarks:site_vars++**:agent_type:0,site_type:0,state:0,var:0->[0]
+Quarks:site_vars++**:agent_type:0,site_type:0,state:0,var:1->[0]
 Quarks:site_vars++**:agent_type:0,site_type:3,state:0,var:0->[0]
+Quarks:site_vars++**:agent_type:0,site_type:3,state:0,var:1->[0]
+Quarks:site_vars++**:agent_type:0,site_type:1,state:1,var:1->[0]
 Quarks:site_test**:agent_type:0,site_type:3,state:0,rule:0->[0]
 Quarks:site_test**:agent_type:0,site_type:3,state:0,rule:1->[0]
 Quarks:site_test**:agent_type:0,site_type:3,state:0,rule:2->[0]
@@ -1133,21 +1144,25 @@ Influence_map:Wake_up_map:rule(11):'r10' A(x{u}[.]),.->A(x{u}[.]),A(x{u}[.],c=0,
 Influence_map:Wake_up_map:rule(12):'r11' .->A(x{u}[.],c=1,d=2) -> rule(0):'r1' A(x[.]),B(x[.])->A(x[1]),B(x[1])[0->0]
 Influence_map:Wake_up_map:rule(12):'r11' .->A(x{u}[.],c=1,d=2) -> rule(1):'r2' A(x[.],c:y,d:y1),B(x[.],c:y2)->A(x[1]),B(x[1])[0->0]
 Influence_map:Wake_up_map:rule(12):'r11' .->A(x{u}[.],c=1,d=2) -> rule(11):'r10' A(x{u}[.]),.->A(x{u}[.]),A(x{u}[.],c=0,d=2)[0->0]
+Influence_map:Wake_up_map:rule(12):'r11' .->A(x{u}[.],c=1,d=2) -> var(1):'A2' A(x{u}[.],c=1)[0->0]
 Influence_map:Wake_up_map:rule(13):'r12' A(c=3,x[1]),B(x[1]),.->A(c-2,x[.]),B(x[.]),A(x[.],c=2,d=1) -> rule(0):'r1' A(x[.]),B(x[.])->A(x[1]),B(x[1])[0->0];[1->1];[2->0]
 Influence_map:Wake_up_map:rule(13):'r12' A(c=3,x[1]),B(x[1]),.->A(c-2,x[.]),B(x[.]),A(x[.],c=2,d=1) -> rule(1):'r2' A(x[.],c:y,d:y1),B(x[.],c:y2)->A(x[1]),B(x[1])[0->0];[1->1];[2->0]
 Influence_map:Wake_up_map:rule(13):'r12' A(c=3,x[1]),B(x[1]),.->A(c-2,x[.]),B(x[.]),A(x[.],c=2,d=1) -> rule(11):'r10' A(x{u}[.]),.->A(x{u}[.]),A(x{u}[.],c=0,d=2)[0->0];[2->0]
 Influence_map:Wake_up_map:rule(13):'r12' A(c=3,x[1]),B(x[1]),.->A(c-2,x[.]),B(x[.]),A(x[.],c=2,d=1) -> rule(16):'r14' A(x{u}[.],c=2)->.[2->0]
 Influence_map:Wake_up_map:rule(13):'r12' A(c=3,x[1]),B(x[1]),.->A(c-2,x[.]),B(x[.]),A(x[.],c=2,d=1) -> rule(17):'r15' A(c>=1,x{u}[.]),A(x{u}[.],c=2)->A(c,x{u}[.]),.[2->1]
 Influence_map:Wake_up_map:rule(13):'r12' A(c=3,x[1]),B(x[1]),.->A(c-2,x[.]),B(x[.]),A(x[.],c=2,d=1) -> rule(18):'r16' .,A(x{u}[.],c=2)->A(x{u}[.],c=1),.[2->1]
+Influence_map:Wake_up_map:rule(13):'r12' A(c=3,x[1]),B(x[1]),.->A(c-2,x[.]),B(x[.]),A(x[.],c=2,d=1) -> var(1):'A2' A(x{u}[.],c=1)[0->0]
 Influence_map:Wake_up_map:rule(14):'r12bis' .,.->A(c=1),A(c=2) -> rule(0):'r1' A(x[.]),B(x[.])->A(x[1]),B(x[1])[0->0];[1->0]
 Influence_map:Wake_up_map:rule(14):'r12bis' .,.->A(c=1),A(c=2) -> rule(1):'r2' A(x[.],c:y,d:y1),B(x[.],c:y2)->A(x[1]),B(x[1])[0->0];[1->0]
 Influence_map:Wake_up_map:rule(14):'r12bis' .,.->A(c=1),A(c=2) -> rule(11):'r10' A(x{u}[.]),.->A(x{u}[.]),A(x{u}[.],c=0,d=2)[0->0];[1->0]
 Influence_map:Wake_up_map:rule(14):'r12bis' .,.->A(c=1),A(c=2) -> rule(16):'r14' A(x{u}[.],c=2)->.[1->0]
 Influence_map:Wake_up_map:rule(14):'r12bis' .,.->A(c=1),A(c=2) -> rule(17):'r15' A(c>=1,x{u}[.]),A(x{u}[.],c=2)->A(c,x{u}[.]),.[1->1]
 Influence_map:Wake_up_map:rule(14):'r12bis' .,.->A(c=1),A(c=2) -> rule(18):'r16' .,A(x{u}[.],c=2)->A(x{u}[.],c=1),.[1->1]
+Influence_map:Wake_up_map:rule(14):'r12bis' .,.->A(c=1),A(c=2) -> var(1):'A2' A(x{u}[.],c=1)[0->0]
 Influence_map:Wake_up_map:rule(18):'r16' .,A(x{u}[.],c=2)->A(x{u}[.],c=1),. -> rule(0):'r1' A(x[.]),B(x[.])->A(x[1]),B(x[1])[0->0]
 Influence_map:Wake_up_map:rule(18):'r16' .,A(x{u}[.],c=2)->A(x{u}[.],c=1),. -> rule(1):'r2' A(x[.],c:y,d:y1),B(x[.],c:y2)->A(x[1]),B(x[1])[0->0]
 Influence_map:Wake_up_map:rule(18):'r16' .,A(x{u}[.],c=2)->A(x{u}[.],c=1),. -> rule(11):'r10' A(x{u}[.]),.->A(x{u}[.]),A(x{u}[.],c=0,d=2)[0->0]
+Influence_map:Wake_up_map:rule(18):'r16' .,A(x{u}[.],c=2)->A(x{u}[.],c=1),. -> var(1):'A2' A(x{u}[.],c=1)[0->0]
 Influence_map:Inhibition_map:rule(0):'r1' A(x[.]),B(x[.])->A(x[1]),B(x[1]) -> rule(1):'r2' A(x[.],c:y,d:y1),B(x[.],c:y2)->A(x[1]),B(x[1])[0->0];[1->1]
 Influence_map:Inhibition_map:rule(0):'r1' A(x[.]),B(x[.])->A(x[1]),B(x[1]) -> rule(2):'r3' A(x{u}[.])->A(x{p}[.],c+2)[0->0]
 Influence_map:Inhibition_map:rule(0):'r1' A(x[.]),B(x[.])->A(x[1]),B(x[1]) -> rule(3):'r4' A(x{u}[.])->A(x{p}[.],c-2)[0->0]
@@ -1160,6 +1175,7 @@ Influence_map:Inhibition_map:rule(0):'r1' A(x[.]),B(x[.])->A(x[1]),B(x[1]) -> ru
 Influence_map:Inhibition_map:rule(0):'r1' A(x[.]),B(x[.])->A(x[1]),B(x[1]) -> rule(17):'r15' A(c>=1,x{u}[.]),A(x{u}[.],c=2)->A(c,x{u}[.]),.[0->0];[0->1]
 Influence_map:Inhibition_map:rule(0):'r1' A(x[.]),B(x[.])->A(x[1]),B(x[1]) -> rule(18):'r16' .,A(x{u}[.],c=2)->A(x{u}[.],c=1),.[0->1]
 Influence_map:Inhibition_map:rule(0):'r1' A(x[.]),B(x[.])->A(x[1]),B(x[1]) -> var(0):'A1' A(x{u}[.],c>=1)[0->0]
+Influence_map:Inhibition_map:rule(0):'r1' A(x[.]),B(x[.])->A(x[1]),B(x[1]) -> var(1):'A2' A(x{u}[.],c=1)[0->0]
 Influence_map:Inhibition_map:rule(1):'r2' A(x[.],c:y,d:y1),B(x[.],c:y2)->A(x[1]),B(x[1]) -> rule(0):'r1' A(x[.]),B(x[.])->A(x[1]),B(x[1])[0->0];[1->1]
 Influence_map:Inhibition_map:rule(1):'r2' A(x[.],c:y,d:y1),B(x[.],c:y2)->A(x[1]),B(x[1]) -> rule(2):'r3' A(x{u}[.])->A(x{p}[.],c+2)[0->0]
 Influence_map:Inhibition_map:rule(1):'r2' A(x[.],c:y,d:y1),B(x[.],c:y2)->A(x[1]),B(x[1]) -> rule(3):'r4' A(x{u}[.])->A(x{p}[.],c-2)[0->0]
@@ -1172,6 +1188,7 @@ Influence_map:Inhibition_map:rule(1):'r2' A(x[.],c:y,d:y1),B(x[.],c:y2)->A(x[1])
 Influence_map:Inhibition_map:rule(1):'r2' A(x[.],c:y,d:y1),B(x[.],c:y2)->A(x[1]),B(x[1]) -> rule(17):'r15' A(c>=1,x{u}[.]),A(x{u}[.],c=2)->A(c,x{u}[.]),.[0->0];[0->1]
 Influence_map:Inhibition_map:rule(1):'r2' A(x[.],c:y,d:y1),B(x[.],c:y2)->A(x[1]),B(x[1]) -> rule(18):'r16' .,A(x{u}[.],c=2)->A(x{u}[.],c=1),.[0->1]
 Influence_map:Inhibition_map:rule(1):'r2' A(x[.],c:y,d:y1),B(x[.],c:y2)->A(x[1]),B(x[1]) -> var(0):'A1' A(x{u}[.],c>=1)[0->0]
+Influence_map:Inhibition_map:rule(1):'r2' A(x[.],c:y,d:y1),B(x[.],c:y2)->A(x[1]),B(x[1]) -> var(1):'A2' A(x{u}[.],c=1)[0->0]
 Influence_map:Inhibition_map:rule(2):'r3' A(x{u}[.])->A(x{p}[.],c+2) -> rule(3):'r4' A(x{u}[.])->A(x{p}[.],c-2)[0->0]
 Influence_map:Inhibition_map:rule(2):'r3' A(x{u}[.])->A(x{p}[.],c+2) -> rule(4):'r4bis' A(x{u}[.])->A(x{p}[.],c-2)[0->0]
 Influence_map:Inhibition_map:rule(2):'r3' A(x{u}[.])->A(x{p}[.],c+2) -> rule(11):'r10' A(x{u}[.]),.->A(x{u}[.]),A(x{u}[.],c=0,d=2)[0->0]

--- a/tests/integration/kasa_preprocessing/counters/output/influence.dot.ref
+++ b/tests/integration/kasa_preprocessing/counters/output/influence.dot.ref
@@ -27,6 +27,7 @@ digraph G{
 "r16" [shape=box fillcolor="#87ceeb" style=filled];
 
 "A1" [shape=ellipse fillcolor="#98fb98" style=filled];
+"A2" [shape=ellipse fillcolor="#98fb98" style=filled];
 "r1" -> "r4_" [label="[0->0];[1->1]" color="green"];
 "r1" -> "r6" [label="[0->0];[1->1]" color="green"];
 "r1" -> "r7" [label="[0->0];[1->1]" color="green"];
@@ -58,21 +59,25 @@ digraph G{
 "r11" -> "r1" [label="[0->0]" color="green"];
 "r11" -> "r2" [label="[0->0]" color="green"];
 "r11" -> "r10" [label="[0->0]" color="green"];
+"r11" -> "A2" [label="[0->0]" color="green"];
 "r12" -> "r1" [label="[0->0];[1->1];[2->0]" color="green"];
 "r12" -> "r2" [label="[0->0];[1->1];[2->0]" color="green"];
 "r12" -> "r10" [label="[0->0];[2->0]" color="green"];
 "r12" -> "r14" [label="[2->0]" color="green"];
 "r12" -> "r15" [label="[2->1]" color="green"];
 "r12" -> "r16" [label="[2->1]" color="green"];
+"r12" -> "A2" [label="[0->0]" color="green"];
 "r12bis" -> "r1" [label="[0->0];[1->0]" color="green"];
 "r12bis" -> "r2" [label="[0->0];[1->0]" color="green"];
 "r12bis" -> "r10" [label="[0->0];[1->0]" color="green"];
 "r12bis" -> "r14" [label="[1->0]" color="green"];
 "r12bis" -> "r15" [label="[1->1]" color="green"];
 "r12bis" -> "r16" [label="[1->1]" color="green"];
+"r12bis" -> "A2" [label="[0->0]" color="green"];
 "r16" -> "r1" [label="[0->0]" color="green"];
 "r16" -> "r2" [label="[0->0]" color="green"];
 "r16" -> "r10" [label="[0->0]" color="green"];
+"r16" -> "A2" [label="[0->0]" color="green"];
 "r1" -> "r2" [label="[0->0];[1->1]" color="red" arrowhead="tee"];
 "r1" -> "r3" [label="[0->0]" color="red" arrowhead="tee"];
 "r1" -> "r4" [label="[0->0]" color="red" arrowhead="tee"];
@@ -85,6 +90,7 @@ digraph G{
 "r1" -> "r15" [label="[0->0];[0->1]" color="red" arrowhead="tee"];
 "r1" -> "r16" [label="[0->1]" color="red" arrowhead="tee"];
 "r1" -> "A1" [label="[0->0]" color="red" arrowhead="tee"];
+"r1" -> "A2" [label="[0->0]" color="red" arrowhead="tee"];
 "r2" -> "r1" [label="[0->0];[1->1]" color="red" arrowhead="tee"];
 "r2" -> "r3" [label="[0->0]" color="red" arrowhead="tee"];
 "r2" -> "r4" [label="[0->0]" color="red" arrowhead="tee"];
@@ -97,6 +103,7 @@ digraph G{
 "r2" -> "r15" [label="[0->0];[0->1]" color="red" arrowhead="tee"];
 "r2" -> "r16" [label="[0->1]" color="red" arrowhead="tee"];
 "r2" -> "A1" [label="[0->0]" color="red" arrowhead="tee"];
+"r2" -> "A2" [label="[0->0]" color="red" arrowhead="tee"];
 "r3" -> "r4" [label="[0->0]" color="red" arrowhead="tee"];
 "r3" -> "r4bis" [label="[0->0]" color="red" arrowhead="tee"];
 "r3" -> "r10" [label="[0->0]" color="red" arrowhead="tee"];


### PR DESCRIPTION
This PR:
- Adds a function `counter_is_eq` to determine whether a counter check is `>=` or `=`.
- Adds a second `%obs` to `tests/integration/compiler/counters/counters.ka` to check the difference between `>=` and `=`.
- Updates various test reference files.

This PR resolves Issue #672 specifically, but may not be a complete solution for the whole project. For example, [`core/symmetries/kade_backend.ml`](https://github.com/Kappa-Dev/KappaTools/blob/41ddf7782b2be31f25d6ec863544fe486a5c679c/core/symmetries/kade_backend.ml#L170) has a similar issue, and `core/siteGraphs/snapshot.ml` has a [similar function](https://github.com/Kappa-Dev/KappaTools/blob/41ddf7782b2be31f25d6ec863544fe486a5c679c/core/siteGraphs/snapshot.ml#L93) that may have similar effects elsewhere in the codebase.