### PR TITLE
Small-than implementation in counters as translation into new "inverted counter"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           sudo apt-get install --yes gnuplot-nox \
             poppler-utils graphviz texlive-latex-recommended \
             texlive-fonts-recommended texlive-pictures tex4ht
-          opam install --yes dune num yojson lwt fmt logs re \
+          opam install --yes dune num yojson result lwt fmt logs re \
             cohttp-lwt-unix atdgen
           pip install nose
       - name: Make Kappa

--- a/core/KaSa_rep/frontend/prepreprocess.ml
+++ b/core/KaSa_rep/frontend/prepreprocess.ml
@@ -257,6 +257,7 @@ let translate_counter_test test =
   | Ast.CEQ i -> Ckappa_sig.CEQ i
   | Ast.CGTE i -> Ckappa_sig.CGTE i
   | Ast.CVAR x -> Ckappa_sig.CVAR x
+  | Ast.CLTE _i -> failwith "CLTE not yet implemented" (* TODO *)
 
 let fst_opt a_opt =
   match a_opt with

--- a/core/dataStructures/loc.ml
+++ b/core/dataStructures/loc.ml
@@ -12,6 +12,8 @@ type 'a annoted = 'a * t
 
 let v (v, _) = v
 let get_annot (_, annot) = annot
+let copy_annot (_, loc) a = a, loc
+let map_annot f (a, loc) = f a, loc
 
 let of_pos start_location end_location =
   let () =

--- a/core/dataStructures/loc.mli
+++ b/core/dataStructures/loc.mli
@@ -19,6 +19,12 @@ val v : 'a annoted -> 'a
 val get_annot : 'a annoted -> t
 (** Extract annotation from Loc.annoted *)
 
+val copy_annot : 'b annoted -> 'a -> 'a annoted
+(** Create annoted variable with same annotation as existing variable *)
+
+val map_annot : ('a -> 'b) -> 'a annoted -> 'b annoted
+(** Apply operation on variable and keep annotation *)
+
 val of_pos : Lexing.position -> Lexing.position -> t
 val dummy : t
 val annot_with_dummy : 'a -> 'a annoted

--- a/core/grammar/ast.mli
+++ b/core/grammar/ast.mli
@@ -22,7 +22,12 @@ type port = {
 }
 (** Describe a port from an agent. [_int] references the internal state of the port, [_link], the possible links that can be made to this port, [_mod] to the changes in a rule that would be made to the state, used only in edit_notation  *)
 
-type counter_test = CEQ of int | CGTE of int | CVAR of string
+(** What test is done by the counter expression
+ * - CEQ: If counter value is equal to the specified value
+ * - CGTE: If counter value is greater or equal to the specified value
+ * - CLTE: If counter value is less or equal to the specified value
+ * - CVAR: Not a test, but defines a variable to be used in the rule rates *)
+type counter_test = CEQ of int | CGTE of int | CLTE of int | CVAR of string
 
 type counter = {
   counter_name: string Loc.annoted;

--- a/core/grammar/counters_compiler.ml
+++ b/core/grammar/counters_compiler.ml
@@ -557,7 +557,7 @@ let rec add_incr (i : int) (first_link : int) (last_link : int) (delta : int)
   )
 
 let rec link_incr (sigs : Signature.s) (i : int) (nb : int)
-    (ag_info : (int * int) * bool) (equal : bool) (lnk : int) (loc : Loc.t)
+    (ag_info : (int * int) * bool) (equal : bool) (link : int) (loc : Loc.t)
     (delta : int) : LKappa.rule_mixture =
   if i = nb then
     []
@@ -565,38 +565,72 @@ let rec link_incr (sigs : Signature.s) (i : int) (nb : int)
     let is_first = i = 0 in
     let is_last = i = nb - 1 in
     let ra_agent =
-      make_counter_agent sigs (is_first, ag_info) (is_last, equal) (lnk + i)
-        (lnk + i + 1)
+      make_counter_agent sigs (is_first, ag_info) (is_last, equal) (link + i)
+        (link + i + 1)
         loc (delta > 0)
     in
-    ra_agent :: link_incr sigs (i + 1) nb ag_info equal lnk loc delta
+    ra_agent :: link_incr sigs (i + 1) nb ag_info equal link loc delta
   )
 
 let rec erase_incr (sigs : Signature.s) (i : int) (incrs : LKappa.rule_mixture)
-    (delta : int) (lnk : int) : LKappa.rule_mixture =
+    (delta : int) (link : int) : LKappa.rule_mixture =
   let counter_agent_info = Signature.get_counter_agent_info sigs in
   let port_b = fst counter_agent_info.ports in
   match incrs with
   | incr :: incr_s ->
     if i = abs delta then (
       let before, _ = incr.LKappa.ra_ports.(port_b) in
-      incr.LKappa.ra_ports.(port_b) <- before, LKappa.Linked lnk;
+      incr.LKappa.ra_ports.(port_b) <- before, LKappa.Linked link;
       incr :: incr_s
     ) else (
       Array.iteri
         (fun i (a, _) -> incr.LKappa.ra_ports.(i) <- a, LKappa.Erased)
         incr.LKappa.ra_ports;
       let rule_agent = { incr with LKappa.ra_erased = true } in
-      rule_agent :: erase_incr sigs (i + 1) incr_s delta lnk
+      rule_agent :: erase_incr sigs (i + 1) incr_s delta link
     )
   | [] -> []
 
+(** Returns mixtures for agnet with site changed from counter to port, as well as new [link_nb] after previous additions
+ * Used by [compile_counter_in_rule_agent]*)
 let counter_becomes_port (sigs : Signature.s) (ra : LKappa.rule_agent)
-    (p_id : int) ((delta, loc_delta) : int Loc.annoted) (loc : Loc.t)
-    (equal : bool) (test : int) (start_link_nb : int) :
-    LKappa.rule_mixture * Raw_mixture.t =
+    (p_id : int) (counter : Ast.counter) (start_link_nb : int) :
+    (LKappa.rule_mixture * Raw_mixture.t) * int =
+  (* Returns positive part of value *)
+  let positive_part (i : int) : int =
+    if i < 0 then
+      0
+    else
+      i
+  in
+
+  let loc : Loc.t = Loc.get_annot counter.Ast.counter_name in
+  let (delta, loc_delta) : int * Loc.t = counter.Ast.counter_delta in
+  let counter_test : Ast.counter_test Loc.annoted =
+    Option_util.unsome_or_raise
+      ~excep:
+        (ExceptionDefn.Internal_Error
+           ( "Counter "
+             ^ Loc.v counter.Ast.counter_name
+             ^ " should have a test by now",
+             loc ))
+      counter.Ast.counter_test
+  in
+  let (test, equal) : int * bool =
+    match Loc.v counter_test with
+    | Ast.CVAR _ ->
+      raise
+        (ExceptionDefn.Internal_Error
+           ( "Counter "
+             ^ Loc.v counter.Ast.counter_name
+             ^ " defines a variable, which should have been replaced by CEQ \
+                conditions after rule splitting",
+             Loc.get_annot counter_test ))
+    | Ast.CEQ j -> j, true
+    | Ast.CGTE j -> j, false
+  in
   let start_link_for_created : int = start_link_nb + test + 1 in
-  let lnk_for_erased : int = start_link_nb + abs delta in
+  let link_for_erased : int = start_link_nb + abs delta in
   let ag_info : (int * int) * bool =
     (p_id, ra.LKappa.ra_type), ra.LKappa.ra_erased
   in
@@ -606,7 +640,7 @@ let counter_becomes_port (sigs : Signature.s) (ra : LKappa.rule_agent)
   in
   let adjust_delta : LKappa.rule_mixture =
     if delta < 0 then
-      erase_incr sigs 0 test_incr delta lnk_for_erased
+      erase_incr sigs 0 test_incr delta link_for_erased
     else
       test_incr
   in
@@ -628,14 +662,16 @@ let counter_becomes_port (sigs : Signature.s) (ra : LKappa.rule_agent)
     else if delta > 0 then
       LKappa.Linked start_link_for_created
     else
-      LKappa.Linked lnk_for_erased
+      LKappa.Linked link_for_erased
   in
   let counter_agent_info = Signature.get_counter_agent_info sigs in
   let port_b : int = fst counter_agent_info.ports in
   ra.LKappa.ra_ports.(p_id) <-
     ( (LKappa.LNK_VALUE (start_link_nb, (port_b, counter_agent_info.id)), loc),
       switch );
-  adjust_delta, created
+  let new_link_nb : int = start_link_nb + 1 + test + positive_part delta in
+
+  (adjust_delta, created), new_link_nb
 
 (** Compiles the counter precondition in a left hand side mixture of a rule into a mixture which tests dummy positions
  * rule_agent_ - agent with counters in a rule
@@ -646,52 +682,16 @@ let counter_becomes_port (sigs : Signature.s) (ra : LKappa.rule_agent)
 let compile_counter_in_rule_agent (sigs : Signature.s)
     (rule_agent_ : LKappa.rule_agent with_agent_counters) (lnk_nb : int) :
     LKappa.rule_mixture * Raw_mixture.t * int =
-  (* Returns positive part of value *)
-  let positive_part (i : int) : int =
-    if i < 0 then
-      0
-    else
-      i
-  in
-
   let (incrs, lnk_nb') : (LKappa.rule_mixture * Raw_mixture.t) list * int =
     Tools.array_fold_lefti
       (fun id (acc_incrs, lnk_nb) -> function
         | None -> acc_incrs, lnk_nb
         | Some (counter, _) ->
-          let loc = Loc.get_annot counter.Ast.counter_name in
-          let test =
-            Option_util.unsome_or_raise
-              ~excep:
-                (ExceptionDefn.Internal_Error
-                   ( "Counter "
-                     ^ Loc.v counter.Ast.counter_name
-                     ^ " should have a test by now",
-                     loc ))
-              counter.Ast.counter_test
+          let new_incrs, new_lnk_nb =
+            counter_becomes_port sigs rule_agent_.agent id counter lnk_nb
           in
-          let delta = counter.Ast.counter_delta in
-          (match Loc.v test with
-          | Ast.CEQ j ->
-            ( counter_becomes_port sigs rule_agent_.agent id delta loc true j
-                lnk_nb
-              :: acc_incrs,
-              lnk_nb + 1 + j + positive_part (Loc.v delta) )
-            (* JF: link ids were colliding after counter decrementations -> I do not think that we should add delta when negative *)
-          | Ast.CGTE j ->
-            ( counter_becomes_port sigs rule_agent_.agent id delta loc false j
-                lnk_nb
-              :: acc_incrs,
-              lnk_nb + 1 + j + positive_part (Loc.v delta) )
-            (* JF: link ids were colliding after counter decrementations -> I do not think that we should add delta when negative *)
-          | Ast.CVAR _ ->
-            raise
-              (ExceptionDefn.Internal_Error
-                 ( "Counter "
-                   ^ Loc.v counter.Ast.counter_name
-                   ^ " defines a variable, which should have been replaced by \
-                      CEQ conditions after rule splitting",
-                   Loc.get_annot test ))))
+          new_incrs :: acc_incrs, new_lnk_nb
+        (* JF: link ids were colliding after counter decrementations -> I do not think that we should add delta when negative *))
       ([], lnk_nb) rule_agent_.counters
   in
   let (als, bls) : LKappa.rule_mixture * Raw_mixture.t =
@@ -720,11 +720,6 @@ let compile_counter_in_raw_agent (sigs : Signature.s)
             agent_name c.Ast.counter_name
         | Some (test, _) ->
           (match test with
-          | Ast.CEQ j ->
-            let p = Raw_mixture.VAL lnk_nb in
-            let () = ports.(p_id) <- p in
-            let incrs = add_incr 0 lnk_nb (lnk_nb + j) (j + 1) true sigs in
-            acc @ incrs, lnk_nb + j + 1
           | Ast.CGTE _ | Ast.CVAR _ ->
             let agent_name =
               Format.asprintf "@[%a@]"
@@ -732,7 +727,12 @@ let compile_counter_in_raw_agent (sigs : Signature.s)
                 raw_agent.Raw_mixture.a_type
             in
             LKappa.raise_not_enough_specified ~status:"counter" ~side:"left"
-              agent_name c.Ast.counter_name)))
+              agent_name c.Ast.counter_name
+          | Ast.CEQ j ->
+            let p = Raw_mixture.VAL lnk_nb in
+            let () = ports.(p_id) <- p in
+            let incrs = add_incr 0 lnk_nb (lnk_nb + j) (j + 1) true sigs in
+            acc @ incrs, lnk_nb + j + 1)))
     ([], lnk_nb) raw_agent_.counters
 
 let raw_agent_has_counters (ag_ : 'a with_agent_counters) : bool =

--- a/core/grammar/kappaParser.mly
+++ b/core/grammar/kappaParser.mly
@@ -448,6 +448,7 @@ interface_expression:
 counter_test:
    | TYPE INT { Some (Ast.CEQ $2,rhs_pos 2)}
    | TYPE GREATER INT { Some (Ast.CGTE $3,rhs_pos 3)}
+   | TYPE SMALLER INT { Some (Ast.CLTE $3,rhs_pos 3)}
    | TYPE ID { Some (Ast.CVAR $2,rhs_pos 2)}
 
 port_expression:

--- a/core/grammar/kparser4.mly
+++ b/core/grammar/kparser4.mly
@@ -129,6 +129,7 @@ counter_modif:
 counter_test:
   | EQUAL annoted INT { (Ast.CEQ $3,rhs_pos 3) }
   | GREATER annoted EQUAL annoted INT { (Ast.CGTE $5,rhs_pos 5) }
+  | SMALLER annoted EQUAL annoted INT { (Ast.CLTE $5,rhs_pos 5) }
   | EQUAL annoted ID { (Ast.CVAR $3,rhs_pos 3) }
   ;
 

--- a/core/term/lKappa.ml
+++ b/core/term/lKappa.ml
@@ -192,18 +192,16 @@ let print_rule_intf ~noCounters sigs ~show_erased ~ltypes ag_ty f
                  Mods.DynArray.get counters.Raw_mixture.rank root
                in
                if is_counter' && not noCounters then (
-                 let () =
-                   Format.fprintf f "%t%a{%a%a}"
-                     (if empty then
-                        Pp.empty
-                      else
-                        Pp.space)
-                     (Signature.print_site sigs ag_ty)
-                     i print_counter_test
-                     (c - 1, eq)
-                     (print_counter_delta created_counters j)
-                     switch
-                 in
+                 Format.fprintf f "%t%a{%a%a}"
+                   (if empty then
+                      Pp.empty
+                    else
+                      Pp.space)
+                   (Signature.print_site sigs ag_ty)
+                   i print_counter_test
+                   (c - 1, eq)
+                   (print_counter_delta created_counters j)
+                   switch;
                  true
                ) else
                  false

--- a/core/term/raw_mixture.mli
+++ b/core/term/raw_mixture.mli
@@ -27,6 +27,7 @@ val print :
 val to_json : t -> Yojson.Basic.t
 val of_json : Yojson.Basic.t -> t
 
+(* TODO Change this to have equal bool as sum type *)
 type incr_t = {
   father: int Mods.DynArray.t;
   rank: (int * (bool * bool)) Mods.DynArray.t;

--- a/tests/integration/compiler/counters_smaller_than/README
+++ b/tests/integration/compiler/counters_smaller_than/README
@@ -1,0 +1,2 @@
+#Command-line:
+"${KAPPABIN}"KaSim -l 1 counters_smaller_than.ka -seed 23014 -d output -syntax 4 || true

--- a/tests/integration/compiler/counters_smaller_than/counters_smaller_than.ka
+++ b/tests/integration/compiler/counters_smaller_than/counters_smaller_than.ka
@@ -1,0 +1,21 @@
+%agent: A(c{=0 / += 7})
+%agent: B()
+
+'rule_a' A(c{<=2}) -> A(c{+=1}) @ 1
+'rule_b' A(c{>=5}) -> A(c{-=1}) @ 1
+'rule_c' A(c{=3}) -> A(c{+=1}) @ 1
+'rule_aa' A(c{<=1}),. -> ., B() @ 0.2
+
+%init: 10 A(c{=0})
+%init: 10 A(c{=7})
+
+// %obs: 'A' |A()|
+%obs: 'B' |B()|
+%obs: 'A0' |A(c{=0})|
+%obs: 'A1' |A(c{=1})|
+%obs: 'A2' |A(c{=2})|
+%obs: 'A3' |A(c{=3})|
+%obs: 'A4' |A(c{=4})|
+%obs: 'A5' |A(c{=5})|
+%obs: 'A6' |A(c{=6})|
+%obs: 'A7' |A(c{=7})|

--- a/tests/integration/compiler/counters_smaller_than/output/LOG.ref
+++ b/tests/integration/compiler/counters_smaller_than/output/LOG.ref
@@ -1,0 +1,19 @@
+Parsing counters_smaller_than.ka...
+done
++ simulation parameters
++ Sanity checks
++ Compiling...
++ Building initial simulation conditions...
+	 -variable declarations
+	 -rules
+	 -interventions
+	 -observables
+	 -update_domain construction
+	 28 (sub)observables 58 navigation steps
+	 -initial conditions
++ Building initial state (200 agents)
+Done
++ Command line to rerun is: 'KaSim' '-l' '1' 'counters_smaller_than.ka' '-seed' '23014' '-d' 'output' '-syntax' '4'
+______________________________________________________________________
+######################################################################
+Simulation ended

--- a/tests/integration/compiler/counters_smaller_than/output/data.csv.ref
+++ b/tests/integration/compiler/counters_smaller_than/output/data.csv.ref
@@ -1,0 +1,4 @@
+# Output of 'KaSim' '-l' '1' 'counters_smaller_than.ka' '-seed' '23014' '-d' 'output' '-syntax' '4'
+"[T]","B","A0","A1","A2","A3","A4","A5","A6","A7"
+0.,0,10,0,0,0,0,0,0,10
+1.,2,3,2,2,0,1,2,3,5

--- a/tests/integration/compiler/counters_smaller_than/output/inputs.ka.ref
+++ b/tests/integration/compiler/counters_smaller_than/output/inputs.ka.ref
@@ -1,0 +1,44 @@
+%def: "seed" "23014"
+%def: "dumpIfDeadlocked" "true"
+%def: "maxConsecutiveClash" "3"
+%def: "progressBarSize" "70"
+%def: "progressBarSymbol" "#"
+%def: "plotPeriod" "1" "t.u."
+%def: "outputFileName" "data.csv"
+
+
+%agent: A(c{=0/+=7} c__inverted{=0/+=7})
+%agent: B()
+
+%var:/*0*/ 'B' |B()|
+%var:/*1*/ 'A0' |A(c{=0})|
+%var:/*2*/ 'A1' |A(c{=1})|
+%var:/*3*/ 'A2' |A(c{=2})|
+%var:/*4*/ 'A3' |A(c{=3})|
+%var:/*5*/ 'A4' |A(c{=4})|
+%var:/*6*/ 'A5' |A(c{=5})|
+%var:/*7*/ 'A6' |A(c{=6})|
+%var:/*8*/ 'A7' |A(c{=7})|
+%plot: [T]
+%plot: B
+%plot: A0
+%plot: A1
+%plot: A2
+%plot: A3
+%plot: A4
+%plot: A5
+%plot: A6
+%plot: A7
+
+'rule_a' A(c{>=0/+=1} c__inverted{>=5/+=-1}) @ 1
+'rule_b' A(c{>=5/+=-1} c__inverted{>=0/+=1}) @ 1
+'rule_c' A(c{=3/+=1} c__inverted{>=1/+=-1}) @ 1
+'rule_aa' A(c[#] c__inverted{>=6})-, B()+ @ 0.2
+
+/*0*/%mod: (|A(c__inverted{=8})| = 1) do $PRINTF ""; $PRINTF "Counter c__inverted of agent A reached maximum"; $STOP "counter_perturbation.ka"; repeat [false]
+/*1*/%mod: (|A(c{=8})| = 1) do $PRINTF ""; $PRINTF "Counter c of agent A reached maximum"; $STOP "counter_perturbation.ka"; repeat [false]
+
+%init: 10 A(c{=0} c__inverted{=7})
+%init: 10 A(c{=7} c__inverted{=0})
+
+%mod: [E] = 19 do $STOP;

--- a/tests/integration/compiler/site_mismatch/output/LOG.ref
+++ b/tests/integration/compiler/site_mismatch/output/LOG.ref
@@ -73,4 +73,4 @@ every agent may occur in the model
 ------------------------------------------------------------
 
 Some exceptions have been raised
-error: file_name: core/KaSa_rep/frontend/prepreprocess.ml; message: line 718, File "crash.ka", line 4, characters 5-69:: missaligned rule: the rule is ignored; exception:Exit
+error: file_name: core/KaSa_rep/frontend/prepreprocess.ml; message: line 719, File "crash.ka", line 4, characters 5-69:: missaligned rule: the rule is ignored; exception:Exit


### PR DESCRIPTION
Allows `<=` tests in a agent counter. 

Using `<=` will enable in parallel a hidden  _inverted_ counter where the  `>=` test will be made.
Counter logic is planned to be revamped to allow this naturally.

Example of use:

```
%agent: A(c{=0 / += 7})
%agent: B()

'rule_a' A(c{<=2}) -> A(c{+=1}) @ 1
'rule_b' A(c{>=5}) -> A(c{-=1}) @ 1
'rule_c' A(c{=3}) -> A(c{+=1}) @ 1
'rule_aa' A(c{<=1}),. -> ., B() @ 0.2

%init: 10 A(c{=0})
%init: 10 A(c{=7})

// %obs: 'A' |A()|
%obs: 'B' |B()|
%obs: 'A0' |A(c{=0})|
%obs: 'A1' |A(c{=1})|
%obs: 'A2' |A(c{=2})|
%obs: 'A3' |A(c{=3})|
%obs: 'A4' |A(c{=4})|
%obs: 'A5' |A(c{=5})|
%obs: 'A6' |A(c{=6})|
%obs: 'A7' |A(c{=7})|
```

Here, a counter `c__inverted` is added onto agent `A`, which manages the `<=` tests.