### PR TITLE
Fix nix shell environment on Darwin

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -8,16 +8,12 @@
 ##             this directory.
 ##
 
-with import <nixpkgs> {
-##  Building on Apple computers with ARM chips fails. Set the
-##  system type to x86_64 and use Rosetta by uncommenting the
-##  following line.
-#
-#  system = "x86_64-darwin";
-};
+with import <nixpkgs> {};
 clangStdenv.mkDerivation {
   name = "kappa";
-  buildInputs = [
+  buildInputs = lib.optionals clangStdenv.isDarwin [
+   darwin.apple_sdk.frameworks.CoreServices
+  ] ++ [
     gmp.dev
     opam
     pkg-config


### PR DESCRIPTION
Previously, on Apple computers with ARM chips, it was necessary to force the system type to `x86_64`/use Rosetta to use the nix shell environment. Now the Apple SDK and associated frameworks are available in Nix on Darwin, so it's possible to keep the system type as `darwin`.

I've updated `shell.nix` so that the necessary framework is included when the system type `isDarwin`.

