### PR TITLE
Depend on atdgen at build time only

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -63,7 +63,7 @@
    (re ( = 1.11.0 ))
    (fmt ( = 0.9.0 ))
    (logs ( = 0.7.0 ))
-   (atdgen ( = 2.15.0 )) ; TODO: find a way to specify as build dependency only, as with the `build` package variable in opam
+   (atdgen (and :build ( = 2.15.0 )))
    (atdgen-runtime ( = 2.15.0 ))
    kappa-library
    ; Added to pin version of lib used in kappa-library
@@ -87,7 +87,7 @@
    (fmt ( = 0.9.0 ))
    (logs ( = 0.7.0 ))
    (atdgen-runtime ( = 2.15.0 ))
-   (atdgen ( = 2.15.0 )) ; TODO: find a way to specify as build dependency only, as with the `build` package variable in opam
+   (atdgen (and :build ( = 2.15.0 )))
    (tyxml-ppx ( = 4.6.0 ))
    (js_of_ocaml ( = 5.7.0 ))
    (js_of_ocaml-lwt ( = 5.7.0 ))

--- a/kappa-agents.opam
+++ b/kappa-agents.opam
@@ -30,7 +30,7 @@ depends: [
   "re" {= "1.11.0"}
   "fmt" {= "0.9.0"}
   "logs" {= "0.7.0"}
-  "atdgen" {= "2.15.0"}
+  "atdgen" {build & = "2.15.0"}
   "atdgen-runtime" {= "2.15.0"}
   "kappa-library"
   "result" {= "1.5"}

--- a/kappa-webapp.opam
+++ b/kappa-webapp.opam
@@ -32,7 +32,7 @@ depends: [
   "fmt" {= "0.9.0"}
   "logs" {= "0.7.0"}
   "atdgen-runtime" {= "2.15.0"}
-  "atdgen" {= "2.15.0"}
+  "atdgen" {build & = "2.15.0"}
   "tyxml-ppx" {= "4.6.0"}
   "js_of_ocaml" {= "5.7.0"}
   "js_of_ocaml-lwt" {= "5.7.0"}


### PR DESCRIPTION
Hello. I stumbled upon your comment in dune-project while doing some maintenance for atd. This should do the right thing. I tested with `opam build *.opam` which generated opam files that look good.